### PR TITLE
Remove rubygems features due to deprecation:

### DIFF
--- a/lib/puppet/feature/restclient.rb
+++ b/lib/puppet/feature/restclient.rb
@@ -1,4 +1,3 @@
 require 'puppet/util/feature'
 
-Puppet.features.rubygems?
 Puppet.features.add(:restclient, :libs => %w{rest_client})

--- a/lib/puppet/feature/vshield.rb
+++ b/lib/puppet/feature/vshield.rb
@@ -1,4 +1,3 @@
 require 'puppet/util/feature'
 
-Puppet.features.rubygems?
 Puppet.features.add(:vshield, :libs => %w{gyoku nori})

--- a/lib/puppet/feature/vsphere.rb
+++ b/lib/puppet/feature/vsphere.rb
@@ -1,4 +1,3 @@
 require 'puppet/util/feature'
 
-Puppet.features.rubygems?
 Puppet.features.add(:vsphere, :libs => %w{rbvmomi})


### PR DESCRIPTION
Fix the following warning: "Warning: Puppet.features.rubygems? is deprecated.
Require rubygems in your application's entry point if you need it."
