### PR TITLE
added string_keys/symbolize_keys due to sym issue

### DIFF
--- a/lib/puppet/property/vmware.rb
+++ b/lib/puppet/property/vmware.rb
@@ -53,6 +53,7 @@ class Puppet::Property::VMware_Hash < Puppet::Property::VMware
     diff = HashDiff.diff(desire, current)
     diff.empty? or diff.select{|x| x.first != '+'}.empty?
   end
+
 end
 
 # VMware_Array support various forms of array comparison.
@@ -122,6 +123,10 @@ end
 #   newproperty(:server_list, :array_matching => :all, :key => 'ipAddress',
 #               :parent => Puppet::Property::VMware_Array_Hash) { }
 class Puppet::Property::VMware_Array_Hash < Puppet::Property::VMware_Array
+  def munge(value)
+    PuppetX::VMware::Util.string_keys(value)
+  end
+
   def self.key
     @key ||= 'name'
   end

--- a/lib/puppet_x/vmware/util.rb
+++ b/lib/puppet_x/vmware/util.rb
@@ -99,6 +99,30 @@ module PuppetX
         node[keys[-1]] = value
       end
 
+      def self.string_keys(myhash)
+        myhash.keys.each do |key|
+          value = myhash.delete(key)
+          if value.is_a? Hash
+            value = string_keys(value)
+          end
+
+          myhash[(key.to_s rescue key) || key] = value
+        end
+        myhash
+      end
+
+      def self.symbolize_keys(myhash)
+        myhash.keys.each do |key|
+          value = myhash.delete(key)
+          if value.is_a? Hash
+            value = symbolize_keys(value)
+          end
+
+          myhash[(key.to_sym rescue key) || key] = value
+        end
+        myhash
+      end
+
     end
   end
 end


### PR DESCRIPTION
- added string_keys/symbolize_keys to util.rb to be used by vmware_array_hash due to issue with zed/zombie turning the keys into symbols which the vshield_edge provider is expecting strings.
