### PR TITLE
removed require net/ssh since it is already in puppet_x/....

### DIFF
--- a/lib/puppet/provider/file_line/ssh.rb
+++ b/lib/puppet/provider/file_line/ssh.rb
@@ -1,4 +1,3 @@
-require 'net/ssh'
 require 'puppet_x/puppetlabs/transport'
 require 'puppet_x/puppetlabs/transport/ssh'
 

--- a/lib/puppet/provider/service/ssh.rb
+++ b/lib/puppet/provider/service/ssh.rb
@@ -1,4 +1,3 @@
-require 'net/ssh'
 require 'puppet_x/puppetlabs/transport'
 require 'puppet_x/puppetlabs/transport/ssh'
 


### PR DESCRIPTION
removed require net/ssh since it is already in lib/puppet_x/puppetlabs/transport/ssh.rb
