### PR TITLE
Fix provider loading issue in other modules.

### DIFF
--- a/lib/puppet/provider/file_line/ssh.rb
+++ b/lib/puppet/provider/file_line/ssh.rb
@@ -1,5 +1,7 @@
-require 'puppet_x/puppetlabs/transport'
-require 'puppet_x/puppetlabs/transport/ssh'
+require 'pathname'
+mod = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join mod.path, 'lib/puppet_x/puppetlabs/transport'
+require File.join mod.path, 'lib/puppet_x/puppetlabs/transport/ssh'
 
 Puppet::Type.type(:file_line).provide(:ssh) do
   confine :feature => :ssh

--- a/lib/puppet/provider/service/ssh.rb
+++ b/lib/puppet/provider/service/ssh.rb
@@ -1,5 +1,7 @@
-require 'puppet_x/puppetlabs/transport'
-require 'puppet_x/puppetlabs/transport/ssh'
+require 'pathname'
+mod = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join mod.path, 'lib/puppet_x/puppetlabs/transport'
+require File.join mod.path, 'lib/puppet_x/puppetlabs/transport/ssh'
 
 Puppet::Type.type(:service).provide(:ssh) do
   confine :feature => :ssh

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'puppet_x/vmware/util'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 Puppet[:modulepath] = './spec/fixtures/modules'

--- a/spec/unit/puppet_x/puppetlabs/transport_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/transport_spec.rb
@@ -2,7 +2,6 @@
 # Copyright (C) 2013 VMware, Inc.
 
 require 'spec_helper'
-require 'puppet_x/puppetlabs/transport'
 
 module PuppetX::Puppetlabs::Transport
   class Dummy


### PR DESCRIPTION
The module works stand alone, but when included in other modules for spec
testing it causes a dubious load error:

```
Failure/Error: should include_class 'git'
Puppet::Error:
Could not autoload puppet/type/file_line: Could not autoload puppet/provider/file_line/ssh: no such file to load -- puppet_x/puppetlabs/transport
```

This should resolve the load issue in spec testing with no impact to 
functionality.
