### PR TITLE
Define self.instances in ssh service provider

### DIFF
--- a/lib/puppet/provider/service/ssh.rb
+++ b/lib/puppet/provider/service/ssh.rb
@@ -9,6 +9,10 @@ Puppet::Type.type(:service).provide(:ssh) do
 
   include PuppetX::Puppetlabs::Transport
 
+  def self.instances
+    []
+  end
+
   def initd_cmd
     "/etc/init.d/#{resource[:name]}"
   end


### PR DESCRIPTION
This method adds a self.instances method in the
ssh provider for service.

The reason is b/c 'puppet resource service' does not
currently work if the vmware_lib module is installed
b/c it tries to call self.instances for every suitable
provider.
