### PR TITLE
Allow multiple providers for vmware transport

### DIFF
--- a/lib/puppet/provider/transport/default.rb
+++ b/lib/puppet/provider/transport/default.rb
@@ -1,0 +1,23 @@
+Puppet::Type.type(:transport).provide(:default) do
+
+  defaultfor :default_provider => 'true'
+
+  desc 'Basic provider for transport that just returns the value passed into the resource'
+ 
+  def username
+    resource[:username]
+  end
+
+  def password
+    resource[:password]
+  end
+
+  def server
+    resource[:server]
+  end
+
+  def options
+    resource[:options]
+  end
+
+end

--- a/lib/puppet/type/transport.rb
+++ b/lib/puppet/type/transport.rb
@@ -13,7 +13,6 @@ Puppet::Type.newtype(:transport) do
   end
 
   newparam(:server) do
-    defaultto('localhost')
   end
 
   newparam(:options) do

--- a/lib/puppet_x/puppetlabs/transport.rb
+++ b/lib/puppet_x/puppetlabs/transport.rb
@@ -20,10 +20,14 @@ module PuppetX
       # Accepts a puppet resource reference, resource catalog, and loads connetivity info.
       def self.retrieve(options={})
         unless res_hash = options[:resource_hash]
-          catalog = options[:catalog]
-          res_ref = options[:resource_ref].to_s
-          name = Puppet::Resource.new(nil, res_ref).title
-          res_hash = catalog.resource(res_ref).to_hash
+          catalog  = options[:catalog]
+          res_ref  = options[:resource_ref].to_s
+          name     = Puppet::Resource.new(nil, res_ref).title
+          res      = catalog.resource(res_ref)
+          res_hash = res.to_hash
+          [:server, :username, :password, :options].each do |attr|
+            res_hash[attr] ||= res.provider.send(attr)
+          end
         end
 
         provider = options[:provider]


### PR DESCRIPTION
Currently, the transport resource does not have any
providers, it is intended as a simple way to specify
data as resources.

This patch adds basic support for multiple providers so
that credentials can be passed in ways other than as
resources.

This is done by calling the getter methods for
the properties that are used to retrieve credential
information.

For my use case, it will allow me to store credentials in
device.conf files (and to use my custom encryption/decryption
mechanisms.
