### PR TITLE
implement 'preserve' for VMware_Array_Hash

### DIFF
--- a/lib/puppet/property/vmware_array_hash.rb
+++ b/lib/puppet/property/vmware_array_hash.rb
@@ -20,6 +20,15 @@ class Puppet::Property::VMware_Array_Hash < Puppet::Property::VMware_Array
     @inclusive = value
   end
 
+  def self.preserve
+    @preserve ||= :false
+  end
+
+  def self.preserve=(value)
+    raise Puppet::Error, 'VMWare_Array preserve property must be :true or :false.' unless is_symbool? value
+    @preserve = value
+  end
+
   def self.key
     @key ||= 'name'
   end
@@ -41,18 +50,31 @@ class Puppet::Property::VMware_Array_Hash < Puppet::Property::VMware_Array
     true
   end
 
+  def merge_to_preserve should, is, key
+    # turn arrays into hashes with appropriate key
+    h_should = Hash[should.map{|element| [(element.fetch key), element]}]
+    h_is     = Hash[    is.map{|element| [(element.fetch key), element]}]
+    # merge, giving priority to 'should' ; map values to array
+    (h_is.merge h_should).values
+  end
+
   def insync?(is)
     return @should.nil? if is.nil?
     key = self.class.key
 
     inclusive = self.class.inclusive == :true
+    preserve  = self.class.preserve  == :true
     # Allow resources to override inclusive behavior
     inclusive = self.resource.value('inclusive') == :true unless self.resource.value('inclusive').nil?
+    preserve  = self.resource.value('preserve')  == :true unless self.resource.value('preserve').nil?
 
     if inclusive
       match_subset(@should, is, key) and match_subset(is, @should, key)
     else
-      match_subset(@should, is, key)
+      value = match_subset(@should, is, key)
+      (@should = merge_to_preserve @should, is, key) if preserve
+      Puppet.debug "vmware_array_hash insync has match_subset <#{value.inspect}>, preserve <#{preserve}>, is <#{is.inspect}>, @should <#{@should}>"
+      value
     end
   end
 end


### PR DESCRIPTION
- allows adding or modifying element without respecifying
  all existing elements
- needed for (among others)
  - vCD: adding rights to roles (as when adding vCD extensions)
  - vShield: adding static routes or modifying existing routes
  - vShield: enabling or disabling firewall rules without losing
    source, destination, etc.
  - vShield: adding individual sources and destinations without
    requiring full respecification of entire ipsets
