### PR TITLE
nested_value_set -- parameter list change

### DIFF
--- a/lib/puppet_x/vmware/util.rb
+++ b/lib/puppet_x/vmware/util.rb
@@ -81,15 +81,17 @@ module PuppetX
         value
       end
 
-      def self.nested_value_set(hash, keys, value, keys_are_syms=true)
+      def self.nested_value_set(hash, keys, value, transform_keys=:symbol)
         fail "'hash' is not a hash: '#{hash.inspect}'" unless hash.is_a? Hash
         fail "'keys' is not an array: '#{keys.inspect}'" unless keys.is_a? Array
         fail "'keys' array is empty" if keys.empty?
 
         node = hash
-        if keys_are_syms
+        case transform_keys
+        when :false, FalseClass
+        when :symbol
           keys = keys.dup.map{|el| el.to_sym}
-        else
+        when :string
           keys = keys.dup.map{|el| el.to_s}
         end
         Puppet.debug "setting value at #{keys.inspect}"


### PR DESCRIPTION
- 'keys_are_syms' becomes 'transform_keys'
- if neither is used, behavior is unchanged
  (incoming keys are forced to symbols)
- old and new parameters are both optional
  - nested_value_set(hash, keys, value, keys_are_syms=true)
  - nested_value_set(hash, keys, value, transform_keys=:symbol)
- old keys_are_syms  semantics:
  - absent -- incoming keys are forced to symbols
  - true   -- incoming keys are forced to symbols
  - false  -- incoming keys are forced to strings
- new transform_keys semantics:
  - absent  -- incoming keys are forced to symbols
  - :symbol -- incoming keys are forced to symbols
  - :string -- incoming keys are forced to strings
  - :false or false --
             incoming keys are not changed
- change motivated by Gyoku XML serializer, which treats
  the types of keys in a ruby hash as meaningful, and also
  requires certain keys to be symbols (such as :'order!')
