### PR TITLE
Adding confine to limit to kernel=linux

### DIFF
--- a/lib/puppet/provider/service/ssh.rb
+++ b/lib/puppet/provider/service/ssh.rb
@@ -5,6 +5,7 @@ require File.join mod, 'lib/puppet_x/puppetlabs/transport'
 require File.join mod, 'lib/puppet_x/puppetlabs/transport/ssh'
 
 Puppet::Type.type(:service).provide(:ssh) do
+  confine :kernel => [:Linux]
   confine :feature => :ssh
 
   include PuppetX::Puppetlabs::Transport

--- a/lib/puppet_x/puppetlabs/transport/ssh.rb
+++ b/lib/puppet_x/puppetlabs/transport/ssh.rb
@@ -1,4 +1,5 @@
 # Copyright (C) 2013 VMware, Inc.
+confine :kernel => [:Linux]
 require 'net/ssh' unless Puppet.run_mode.master?
 
 module PuppetX::Puppetlabs::Transport


### PR DESCRIPTION
This PR is more of a suggestion then necessarily a well tested fix. The problem we are expierencing is that when trying to compile a catalogue for a windows machine using PE2015.3.1 we get errors such as:
```
Info: Loading facts
Error: Could not autoload puppet/provider/service/ssh: cannot load such file --
net/ssh
Error: Facter: error while resolving custom facts in C:/ProgramData\PuppetLabs\p
uppet\cache\lib\facter\service_provider.rb: Could not autoload puppet/provider/s
ervice/ssh: cannot load such file -- net/ssh
Info: Caching catalog for dbs0000ei2.il2management.local
Error: Failed to apply catalog: undefined method `controllable?' for nil:NilClas
s
```
Adding the changes in the PR prevents these facts from being attempted to be compiled during catalogue compilation. 