### PR TITLE
Replaced Puppet::Transaction override with post_resource_eval provider method

### DIFF
--- a/lib/puppet/provider/transport/default.rb
+++ b/lib/puppet/provider/transport/default.rb
@@ -20,4 +20,8 @@ Puppet::Type.type(:transport).provide(:default) do
     resource[:options]
   end
 
+  def self.post_resource_eval
+    PuppetX::Puppetlabs::Transport.cleanup
+  end
+
 end

--- a/lib/puppet_x/puppetlabs/transport.rb
+++ b/lib/puppet_x/puppetlabs/transport.rb
@@ -1,16 +1,4 @@
 # Copyright (C) 2013 VMware, Inc.
-# Monkey patch transaction to cleanup Transport connection.
-# We need this to cleanup ssh/vcenter/vshield connections regardless of resource apply result.
-module Puppet
-  class Transaction
-    alias_method :evaluate_original, :evaluate
-
-    def evaluate
-      evaluate_original
-      PuppetX::Puppetlabs::Transport.cleanup
-    end
-  end
-end
 
 module PuppetX
   module Puppetlabs


### PR DESCRIPTION
Thanks to @nanliu for the pointer on this one.

#59 describes a problem where, when running this code in puppet agent mode `Puppet::Transaction.evaluate` gets itself into a perpetual loop and eventually bombs out with a `stack level too deep` exception - I'm not sure why there is a difference between puppet apply and puppet agent in this context. 

This PR removes the "monkey patch" (not my words) that overrides the `Puppet::Transaction.evaluate` method and instead provides the `post_resource_eval` method of the provider that Puppet will call just once (it only calls this once *per type*, not per instance)

Test output;

```
Debug: PuppetX::Puppetlabs::Transport::Vsphere closing connection to: vc01.test.local
Debug: Finishing transaction 46129400
Debug: Storing state
Debug: Stored state in 0.03 seconds
Notice: Finished catalog run in 0.39 seconds
```

This seems to have the desired behaviour of cleaning up all connections, once, at the end of the puppet run.
