### PR TITLE
exclude the transport type from `puppet module generate`

### DIFF
--- a/lib/puppet/type/transport.rb
+++ b/lib/puppet/type/transport.rb
@@ -21,6 +21,19 @@ Puppet::Type.newtype(:transport) do
     end
     defaultto({})
   end
+
+  # NOTE: Should match the behavior of the default titlepattern which is to set
+  #       the `name` parameter. Intentionally uses a lambda to disqualify this
+  #       type from compilation by `puppet generate types` so that the
+  #       metaparameter definition below still works.
+  #
+  # FIXME: This is some epic hacky bullshit that will extract a price from
+  #        someone in the future If you're reading this comment, find a way
+  #        to kill this. Good luck and godspeed.
+  def self.title_patterns
+    [[/(.*)/m, [[:name, lambda {|x| x}]]]]
+  end
+
 end
 
 unless Puppet::Type.metaparams.include? :transport

--- a/lib/puppet/type/transport.rb
+++ b/lib/puppet/type/transport.rb
@@ -28,7 +28,7 @@ Puppet::Type.newtype(:transport) do
   #       metaparameter definition below still works.
   #
   # FIXME: This is some epic hacky bullshit that will extract a price from
-  #        someone in the future If you're reading this comment, find a way
+  #        someone in the future. If you're reading this comment, find a way
   #        to kill this. Good luck and godspeed.
   def self.title_patterns
     [[/(.*)/m, [[:name, lambda {|x| x}]]]]


### PR DESCRIPTION
This is a hacky workaround to exclude the transport type from `puppet module generate` to allow it to set the metaparameter even when environment isolation is enabled via means of the .resource_types type metadata directory.

The effect of which is that you should be able to use the vcenter module on modern Puppet infrastructures with environment isolation enabled as normal.

Note that this will still prevent the transport type from being isolated per environment. 

Before this change it is impossible to use the transport type in a modern Puppet agent/master setup. 

Nb: A wee bird (that wishes to remain anonymous) whispered this code in my ear. I can take no credit (or responsibility). 